### PR TITLE
Update ASAv allowed software versions and ASAc docker start script

### DIFF
--- a/autoscale/azure/ARM Template/azure_asav_autoscale.json
+++ b/autoscale/azure/ARM Template/azure_asav_autoscale.json
@@ -55,10 +55,14 @@
       },
       "softwareVersion": {
         "type": "string",
-        "defaultValue": "915.1.0",
+        "defaultValue": "92211.0.0",
         "allowedValues": [
-            "915.1.0",
-            "914.1.10"
+            "916457.0.0",
+            "917139.0.0",
+            "918429.0.0",
+            "919128.0.0",
+            "9203.0.0",
+            "92211.0.0"
         ],
         "metadata": {
             "description": "ASA Software version to use."
@@ -767,4 +771,3 @@
       }
     ]
   }
-  

--- a/autoscale/azure/ARM Template/azure_asav_autoscale_with_GWLB.json
+++ b/autoscale/azure/ARM Template/azure_asav_autoscale_with_GWLB.json
@@ -41,10 +41,14 @@
       },
       "softwareVersion": {
         "type": "string",
-        "defaultValue": "9171.0.0",
+        "defaultValue": "92211.0.0",
         "allowedValues": [
-            "9171.0.0",
-            "914.1.10"
+            "916457.0.0",
+            "917139.0.0",
+            "918429.0.0",
+            "919128.0.0",
+            "9203.0.0",
+            "92211.0.0"
         ],
         "metadata": {
             "description": "ASA Software version to use."

--- a/cluster/azure/Templates/azure_asav_gwlb_cluster.json
+++ b/cluster/azure/Templates/azure_asav_gwlb_cluster.json
@@ -101,9 +101,10 @@
         },
         "softwareVersion": {
             "type": "string",
-            "defaultValue": "92022.0.0",
+            "defaultValue": "92211.0.0",
             "allowedValues": [
-                "92022.0.0"
+                "92211.0.0",
+                "9203.0.0"
             ],
             "metadata": {
                 "description": "ASA Software version to use."

--- a/cluster/azure/Templates/azure_asav_gwlb_cluster_parameters.json
+++ b/cluster/azure/Templates/azure_asav_gwlb_cluster_parameters.json
@@ -42,7 +42,7 @@
         "value": "asav-azure-byol"
       },
       "softwareVersion": {
-        "value": "92022.0.0"
+        "value": "92211.0.0"
       },
       "vmSize": {
         "value": "Standard_D3_v2"

--- a/standalone-asac/docker/start_docker_asac.sh
+++ b/standalone-asac/docker/start_docker_asac.sh
@@ -143,7 +143,7 @@ check_docker_networks
          ${IMAGE_VERSION}"
 
 
- echo "Starting ASA Build Container..."
+ echo "Starting ASA Container..."
  echo $DOCKER_CREATE_CMD
  echo
  echo "Mount Points:"
@@ -158,7 +158,7 @@ check_docker_networks
  
  $DOCKER_CREATE_CMD > /dev/null 2>&1
  if [[ $? -ne 0 ]]; then
-     echo "Error creatting Docker!"
+     echo "Error creating ASAc Docker!"
      exit $?
  fi
 
@@ -181,6 +181,6 @@ check_docker_networks
  echo $DOCKER_START_CMD
  $DOCKER_START_CMD > /dev/null 2>&1
  if [[ $? -ne 0 ]]; then
-     echo "Error creatting Docker!"
+     echo "Error creating ASAc Docker!"
      exit $?
  fi


### PR DESCRIPTION
**Overview**
The current allowed list of software versions for ASAv in the cluster and autoscale templates is out of date.
This change updates allowed software versions for ASAv using the correct Azure marketplace versions.
Also updates logs in ASAc docker start script.